### PR TITLE
Server final

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -40,7 +40,7 @@ SRC     =       main.c \
 		src/server/exec.c \
 		src/server/runtime.c \
 		src/server/thread.c \
-
+		src/test/softwar_test.c \
 
 OBJ     =       ${SRC:%.c=%.o}
 

--- a/server/include/game_manager.h
+++ b/server/include/game_manager.h
@@ -35,18 +35,17 @@ typedef struct	s_game_manager
   int		(*add_player)(t_player *player);
   void		(*set_energy_cells)(t_chain *ecs);
   void		(*set_players_pos)(t_chain *players, uint map_size);
-  void		(*energy_fall)(t_game_info **info);
+  int		(*energy_fall)(t_game_info **info);
   t_game_info	**(*get_info)();
   t_swctx	*(*get_swctx)();
   t_map_manager *(*map_manager)();
   json_object	*(*serialize)(t_game_info *info);
-  int		(*set_change)(int change);
   int		ready;
 }		t_game_manager;
 
 t_game_manager	*get_game_manager();
 json_object	*game_info_to_json(t_game_info *info);
-void		energy_fall(t_game_info **info);
+int		energy_fall(t_game_info **info);
 
 #include "command.h"
 #include "utils.h"

--- a/server/include/softwar_ctx.h
+++ b/server/include/softwar_ctx.h
@@ -29,6 +29,7 @@ typedef struct	s_softwar_context
   char		*active_id;
   zpoller_t	*poller;
   t_chain	*sockets;
+  int		test;
 }		t_swctx;
 
 

--- a/server/include/softwar_test.h
+++ b/server/include/softwar_test.h
@@ -1,0 +1,16 @@
+/*
+** softwar_test.h for SoftWat in 
+** 
+** Made by CASTELLARNAU Aurelien
+** Login   <castel_a@etna-alternance.net>
+** 
+** Started on  Wed Sep 27 16:46:46 2017 CASTELLARNAU Aurelien
+** Last update Wed Sep 27 16:47:27 2017 CASTELLARNAU Aurelien
+*/
+
+#ifndef  _SOFTWAR_TEST_H_
+# define _SOFTWAR_TEST_H_
+
+int	test_softwar(t_game_manager **manager);
+
+#endif  /* !_SOFTWAR_TEST_H_ */

--- a/server/libmy/libmy.h
+++ b/server/libmy/libmy.h
@@ -85,6 +85,8 @@ typedef struct		s_logger
   char			*level;
   void			(*log)(const char*, char*, int);
   char			*file_path;
+  char			*tic_file;
+  int			tic_in_file;
 }			t_logger;
 
 /*
@@ -163,6 +165,7 @@ void		log_error(char *str, FILE *o);
 void		log_warning(char *str, FILE *o);
 void		log_info(char *str, FILE *o);
 void		log_debug(char *str, FILE *o);
+void		log_tic(char *str, FILE *o);
 t_logger	*build_logger(char *opt, t_chain *parameters);
 t_logger	*get_logger();
 void		devlog(const char *func, char *content, int lvl);

--- a/server/libmy/log_panel.c
+++ b/server/libmy/log_panel.c
@@ -11,7 +11,11 @@
 #include <stdio.h>
 #include <time.h>
 #include "libmy.h"
-
+#define NRM  "\x1B[0m"
+#define RED  "\x1B[31m"
+#define GRN  "\x1B[32m"
+#define YEL  "\x1B[33m"
+#define BLU  "\x1B[34m"
 /*
 ** https://stackoverflow.com/questions/1442116/how-to-get-date-and-time-value-in-c-program
 */
@@ -27,27 +31,35 @@ void	print_time(FILE *o)
 void    log_error(char *str, FILE *o)
 {
   print_time(o);
-  fprintf(o, "< ERROR > ");
+  fprintf(o, "%s< ERROR >%s", RED, NRM);
   fprintf(o, str);
 }
 
 void    log_warning(char *str, FILE *o)
 {
   print_time(o);
-  fprintf(o, "< WARNING > ");
+  fprintf(o, "%s< WARNING >%s ", YEL, NRM);
   fprintf(o, str);
 }
 
 void    log_info(char *str, FILE *o)
 {
   print_time(o);
-  fprintf(o, "< INFO > ");
+  fprintf(o, "%s< INFO >%s ", BLU, NRM);
   fprintf(o, str);
 }
 
 void    log_debug(char *str, FILE *o)
 {
   print_time(o);
-  fprintf(o, "< DEBUG > ");
+  fprintf(o, "%s< DEBUG >%s ", GRN, NRM);
+  fprintf(o, str);
+}
+
+void    log_tic(char *str, FILE *o)
+{
+  fprintf(o, "\n");
+  print_time(o);
+  fprintf(o, "<GAME-INFO>");
   fprintf(o, str);
 }

--- a/server/model/game_manager.c
+++ b/server/model/game_manager.c
@@ -16,31 +16,28 @@
 #include "softwar_ctx.h"
 #include "game_manager.h"
 
-int	set_change(int change)
-{
- t_game_info **game_info = get_info();
- (*game_info)->change = change;
- return ((*game_info)->change);
-}
-
 t_player	*get_player(char *identity)
 {
+  t_chain	*players;
   t_link	*tmp;
   t_player	*player;
   char		log[80];
   t_game_info   **game_info;
   
   game_info = get_info();
-  tmp = (*game_info)->players->first;
-  while (tmp)
+  if ((players = (*game_info)->players) != NULL)
     {
-      player = (t_player*)tmp->content;
-      if (!my_strcmp(identity, player->identity))
-	return (player);
-      tmp = tmp->next;
+      tmp = players->first;
+      while (tmp)
+	{
+	  player = (t_player*)tmp->content;
+	  if (!my_strcmp(identity, player->identity))
+	    return (player);
+	  tmp = tmp->next;
+	}
+      sprintf(log, "player with identity '%s' not found", identity);
+      my_log(__func__, log, 2);
     }
-  sprintf(log, "player with identity '%s' not found", player->identity);
-  my_log(__func__, log, 2);
   return (NULL);
 }
 
@@ -62,7 +59,7 @@ void			set_players_pos(t_chain *players, uint map_size)
   int			looking[4] = {1, 1, 4, 4};
 
   i = 0;
-  node_player = (players->first);
+  node_player = players->first;
   while (node_player) {
     player = (t_player*)node_player->content;
     player->x = x[i];
@@ -81,7 +78,7 @@ t_chain		*get_energy_cells()
   return ((*game_info)->energy_cells);
 }
 
-void		energy_fall(t_game_info **info)
+int		energy_fall(t_game_info **info)
 {
   int		x;
   int		y;
@@ -90,7 +87,8 @@ void		energy_fall(t_game_info **info)
   t_map_manager *map;
   uint		map_size;
   
-  map = get_map_manager();
+  if ((map = get_map_manager()) == NULL)
+    return (1);
   map_size = (*info)->map_size;
   x = rand() % (map_size + 1);
   y = rand() % (map_size + 1);
@@ -100,14 +98,14 @@ void		energy_fall(t_game_info **info)
       if (map->is_free_square(x, y, (*info)->players, (*info)->energy_cells))
 	{
 	  if ((ecs = create_energy_cell(x, y, power)) == NULL)
-	    return;
+	    return (1);
 	  if (add_link(&((*info)->energy_cells), ecs))
-	    return;
+	    return (1);
 	}
       else
 	energy_fall(info);
     }
-  return;
+  return (0);
 }
 
 int		add_player(t_player *player)
@@ -197,7 +195,6 @@ t_game_manager		*get_game_manager()
       manager->serialize	 = &game_info_to_json;
       manager->map_manager       = &get_map_manager;
       manager->get_swctx         = &get_swctx;
-      manager->set_change	 = &set_change;
       manager->ready		 = 0; 		
     }
   return (manager);

--- a/server/src/server/command.c
+++ b/server/src/server/command.c
@@ -49,20 +49,14 @@ char	*generate_output(int success)
 char	*generate_output_param(int success, char *param)
 {
   char	tmp[80];
-  char  log[80];
   char	*output;
 
-  my_log(__func__, "generating output", 4);
-  sprintf(log, "Softwar is generating an output with parameter: %s", param);
-  my_log(__func__, log, 3);
   if (success)
     sprintf(tmp, "ok|%s", param);
   else
     sprintf(tmp, "ko|");
   if ((output = my_strdup(tmp)) == NULL)
     return (NULL);
-  sprintf(log, "returnin output: %s", output);
-  my_log(__func__, log, 4);
   return (output);
 }
 
@@ -83,7 +77,7 @@ t_player	*check_uid(t_chain *players, char *id)
       if (!my_strcmp(p->identity, id))
 	{
 	  sprintf(log, "Identity %s already taken", id);
-	  my_log(__func__, log, 4);
+	  my_log(__func__, log, 2);
 	  return (p);
 	}
       tmp = tmp->next;
@@ -99,12 +93,10 @@ char		*identify(t_game_manager **manager, char *identity, char *optional)
   char		log[50];
   t_player	*new;
 
-  my_log(__func__, identity, 3);
-  my_log(__func__, optional, 3);
-  //new = NULL;
+  my_log(__func__, identity, 4);
   if ((*manager)->ready)
     {
-      my_log(__func__, "server full", 4);
+      my_log(__func__, "a client attempt to connect but the server is full", 3);
       return (generate_output_param(FAIL, "server_full"));
     }
   if ((new = check_uid((*manager)->get_players(), optional)) != NULL)
@@ -112,7 +104,7 @@ char		*identify(t_game_manager **manager, char *identity, char *optional)
       if (new->disabled == -1)
 	{
 	  sprintf(log, "client with id %s war disconnected, new client take his place", new->identity);
-	  my_log(__func__, log, 2);
+	  my_log(__func__, log, 3);
 	  new->disabled = 0;
 	}
       else
@@ -120,10 +112,16 @@ char		*identify(t_game_manager **manager, char *identity, char *optional)
     }
   sprintf(log, "Server accept new client with id: %s", optional);
   my_log(__func__, log, 3);
-  if (new == NULL && (new = create_player(optional)) == NULL)
+  if (new != NULL && (*manager)->add_player(new))
     return (NULL);
-  if ((*manager)->add_player(new))
+  else if(new == NULL && (new = create_player(optional)) != NULL)
+    {
+      if ((*manager)->add_player(new))
+	return (NULL);
+    }
+  else
     return (NULL);
+  (*manager)->set_players_pos((*manager)->get_players(), (*manager)->get_map_size());
   sprintf(log, "number of client actually registered: %d", (*manager)->get_players()->index);
   my_log(__func__, log, 3);
   if ((*manager)->get_players()->index >= 4)
@@ -136,7 +134,7 @@ char		*identify(t_game_manager **manager, char *identity, char *optional)
 
 char		*self_id(t_game_manager **manager, char *identity, char *optional)
 {
-  char		log[50];
+  char		log[1024];
   t_player	*p;
 
   // pas obligatoire mais permet d'utiliser tout les paramètres
@@ -166,8 +164,6 @@ char		*leave(t_game_manager **manager, char *identity, char *optional)
 
   
   players = (*manager)->get_players();
-  my_log(__func__, "call function leave", 3);
-  my_log(__func__, optional, 3);
   if ((p = (*manager)->get_player(identity)) == NULL)
     {
       sprintf(log, "can't retrieve client with id %s", identity);
@@ -185,7 +181,6 @@ char		*leave(t_game_manager **manager, char *identity, char *optional)
     p->disabled = -1;
   else
     { 
-      my_log(__func__, p->identity, 3);
       rm_link = remove_link(&players, tmp);
       if (rm_link == -1)
 	my_log(__func__, "no more players", 3);
@@ -198,6 +193,7 @@ char		*leave(t_game_manager **manager, char *identity, char *optional)
       if ((*gi)->game_status != 1 && players->index < 4)
 	(*manager)->ready = 0;
     }
+  my_log(__func__, optional, 4);
   return (generate_output(SUCCESS));
 }
 
@@ -211,12 +207,12 @@ char		*forward(t_game_manager **manager, char *identity, char *optional)
   t_player	*p;
   
   success = 0;
+  my_log(__func__, optional, 4);
+  sprintf(log, "forward done");
   if ((p = (*manager)->get_player(identity)) == NULL)
     return (NULL);
   if ((*manager)->ready && !p->disabled)
     {    
-      sprintf(log, "manager ready, parameter: %s", identity);
-      my_log(__func__, log, 4);
       switch (p->looking)
 	{
 	case LEFT:
@@ -268,15 +264,10 @@ char		*forward(t_game_manager **manager, char *identity, char *optional)
 	    }
 	  break;
 	default:
-	  my_log(__func__, "falled in default in forward switch", 3);
 	  break;
 	}
+      my_log(__func__, log, 4);
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, log, 4);
-  my_log(__func__, "call function forward", 3);
-  my_log(__func__, optional, 3);
   return (generate_output(success));
 }
 
@@ -287,10 +278,10 @@ char		*backward(t_game_manager **manager, char *identity, char *optional)
   t_player	*p;
 
   success = 0;
+  my_log(__func__, optional, 4);
   if ((p = (*manager)->get_player(identity)) == NULL)
     return (NULL);
   if ((*manager)->ready && !p->disabled) {
-    sprintf(log, "manager ready, parameter: %s", identity);
     switch (p->looking)
       {
       case LEFT:
@@ -345,10 +336,6 @@ char		*backward(t_game_manager **manager, char *identity, char *optional)
 	break;
       }
   }
- else
-   sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function backward", 3);
-  my_log(__func__, optional, 3);
   return (generate_output(success));
 }
 
@@ -363,7 +350,6 @@ char		*left(t_game_manager **manager, char *identity, char *optional)
     return (NULL);
   if ((*manager)->ready && !player->disabled)
     {
-      sprintf(log, "manager ready, parameter: %s", identity);
       if (player->action < 5)
 	sprintf(log, "%s action point are too low", identity);
       else
@@ -373,9 +359,6 @@ char		*left(t_game_manager **manager, char *identity, char *optional)
 	  success = 1;
 	}
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function left", 3);
   my_log(__func__, optional, 3);
   return (generate_output(success));
 }
@@ -391,9 +374,6 @@ char		*right(t_game_manager **manager, char *identity, char *optional)
     return (NULL);
   if ((*manager)->ready && !player->disabled)
     {
-      sprintf(log, "manager ready, parameter: %s", identity);
-      my_log(__func__, log, 4);
-      sprintf(log, "manager ready, looking: %d before right", player->looking);
       if (player->action < 5) {
 	sprintf(log, "%s action point are too low", identity);
 	my_log(__func__, log, 4);
@@ -405,9 +385,6 @@ char		*right(t_game_manager **manager, char *identity, char *optional)
 	  success = 1;
 	}
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function right", 3);
   my_log(__func__, optional, 3);
   return (generate_output(success));
 }
@@ -423,7 +400,6 @@ char		*leftfwd(t_game_manager **manager, char *identity, char *optional)
     return (NULL);
   if ((*manager)->ready && !player->disabled)
     {
-      sprintf(log, "manager ready, parameter: %s", identity);
       if (player->action < 10)
 	sprintf(log, "%s action point are too low", identity);
       else
@@ -435,11 +411,7 @@ char		*leftfwd(t_game_manager **manager, char *identity, char *optional)
 	  success = 1;
 	}
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function leftfwd", 3);
   my_log(__func__, optional, 3);
-  (*manager)->set_change(1);
   return (generate_output(success));
 }
 
@@ -454,7 +426,6 @@ char		*rightfwd(t_game_manager **manager, char *identity, char *optional)
     return (NULL);
   if ((*manager)->ready && !player->disabled)
     {
-      sprintf(log, "manager ready, parameter: %s", identity);
       if (player->action < 10)
 	sprintf(log, "%s action point are too low", identity);
       else
@@ -470,9 +441,6 @@ char		*rightfwd(t_game_manager **manager, char *identity, char *optional)
 	  success = 1;
 	}
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function rightfwd", 3);
   my_log(__func__, optional, 3);
   return (generate_output(success));
 }
@@ -482,7 +450,6 @@ char		*rightfwd(t_game_manager **manager, char *identity, char *optional)
 */
 char		*looking(t_game_manager **manager, char *identity, char *optional)
 {
-  char		log[50];
   t_player	*p;
   char		look[2];
 
@@ -491,12 +458,8 @@ char		*looking(t_game_manager **manager, char *identity, char *optional)
   if ((*manager)->ready && !p->disabled)
     {
       sprintf(look, "%d", p->looking);
-      (*manager)->set_change(1);
       return (generate_output_param(SUCCESS, look));
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function looking", 3);
   my_log(__func__, optional, 3);
   return (generate_output(FAIL));
 }
@@ -530,33 +493,28 @@ char		*gather(t_game_manager **manager, char *identity, char *optional)
   energy_cells = (*manager)->get_energy_cells();
   if ((*manager)->ready)
     {
-      sprintf(log, "manager ready, parameter: %s", identity);
       if ((ec = is_energy_cell(player->x, player->y, energy_cells)) != NULL)
 	{
-	  sprintf(log, "player gathered %d energy", ec->value);
-	  my_log(__func__, log, 4);
+	  sprintf(log, "player %s gathered %d energy", player->identity, ec->value);
+	  my_log(__func__, log, 3);
 	  player->energy += ec->value;
 	  player->action -= 1;
 	  if ((link = get_link_by_content(ec, energy_cells)) != NULL)
 	    {
 	      removelink = remove_link(&energy_cells, link);
-	      sprintf(log, "value of remove_link() return: %d", removelink);
-	      my_log(__func__, log, 4);
 	      if (removelink == 1)
-		my_log(__func__, "delete energy cell failed", 3);
+		my_log(__func__, "delete energy cell failed", 2);
 	      else if (removelink == -1)
-		my_log(__func__, "no more energy_cell", 4);
+		my_log(__func__, "no more energy_cell on map", 3);
 	      else
-		my_log(__func__, "energy cell consumed", 2);
+		my_log(__func__, "energy cell consumed", 3);
 	    }
 	  else
-	    my_log(__func__, "try retrieving t_link by energy_cell content failed", 3);
-	  (*manager)->set_change(1);
+	    my_log(__func__, "try retrieving t_link by energy_cell content failed", 2);
 	  return (generate_output(SUCCESS));
 	}
     }
-  else
-      sprintf(log, "manager not ready, parameter: %s", optional);
+  my_log(__func__, optional, 4);
   return (generate_output(FAIL));
 }
 
@@ -589,21 +547,17 @@ char		*watch(t_game_manager **manager, char *identity, char *optional)
 	return (NULL);
       if ((state = compile_watch_return(manager, zone)) == NULL)
 	{
-	  my_log(__func__, "compiling watch return failed", 4);
+	  my_log(__func__, "compiling watch return failed", 2);
 	  return (NULL);
 	}
       return (generate_output_param(SUCCESS, state));
     }
-  else
-    sprintf(log, "manager not ready, processus %s wanted to watch", identity);
-  my_log(__func__, "call function watch", 3);
-  my_log(__func__, optional, 3);
+  my_log(__func__, optional, 4);
   return (generate_output(FAIL));
 }
 
 char		*attack(t_game_manager **manager, char *identity, char *optional)
 {
-  char		log[50];
   char		*watched;
   char		*front;
   t_player	*p;
@@ -612,29 +566,20 @@ char		*attack(t_game_manager **manager, char *identity, char *optional)
   if ((p = (*manager)->get_player(identity)) == NULL)
     return (NULL);
   if ((*manager)->ready && !p->disabled) {
-      sprintf(log, "manager ready, parameter: %s", identity);
-      if ((watched = watch(manager, identity, optional)) == NULL)
+     if ((watched = watch(manager, identity, optional)) == NULL)
 	return (NULL);
       if ((front = extract_front_from_watched(watched)) == NULL)
 	return (NULL);
-      my_log(__func__, front, 4);
       if (p->action < 5)
 	return (generate_output(FAIL));
       p->action -= 5;
       p->energy -= 10;
       if ((adv = (*manager)->get_player(front)) == NULL)
-	{
-	  sprintf(log, "attack will not hit player, can't retrieve %s", front);
-	  my_log(__func__, log, 2);
-	  return (NULL);
-	}
+	return (NULL);
       adv->disabled = 2;
       return (generate_output(SUCCESS));
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function attack", 3);
-  my_log(__func__, optional, 3);
+  my_log(__func__, optional, 4);
   return (generate_output(FAIL));
 }
 
@@ -643,15 +588,13 @@ char		*jump(t_game_manager **manager, char *identity, char *optional)
   int		success;
   char		log[50];
   t_player	*p;
-
+  
   success = 0;
   if ((p = (*manager)->get_player(identity)) == NULL)
     return (NULL);
   if ((*manager)->ready && !p->disabled) {    
-    sprintf(log, "manager ready, parameter: %s", identity);
-    p = (*manager)->get_player(identity);
-    sprintf(log, "player is looking: %d", p->looking);
-    my_log(__func__, log, 4);
+    if ((p = (*manager)->get_player(identity)) == NULL)
+      return (NULL);
     switch (p->looking)
       {
       case LEFT:
@@ -667,10 +610,8 @@ char		*jump(t_game_manager **manager, char *identity, char *optional)
 	  }
 	break;
       case UP:
-	if (check_mvmnt(p->x, p->y - 2, identity, (*manager)) == 1) {
+	if (check_mvmnt(p->x, p->y - 2, identity, (*manager)) == 1)
 	  sprintf(log, "%s can't jump  up", identity);
-	  my_log(__func__, log, 3);
-	}
 	else if (p->energy < 2)
 	  sprintf(log, "%s action point are too low", identity);
 	else
@@ -682,15 +623,9 @@ char		*jump(t_game_manager **manager, char *identity, char *optional)
 	break;
       case RIGHT:
 	if (check_mvmnt(p->x + 2, p->y, identity, (*manager)) == 1)
-	  {
-	    my_putstr("wall right");
-	    sprintf(log, "%s can't jump right", identity);
-	  }
+	  sprintf(log, "%s can't jump right", identity);
 	else if (p->energy < 2)
-	  {
-	    my_putstr("energy fail");
-	    sprintf(log, "%s action point are too low", identity);
-	  }
+	  sprintf(log, "%s action point are too low", identity);
 	else
 	  {
 	    p->energy = p->energy - 2;
@@ -712,36 +647,25 @@ char		*jump(t_game_manager **manager, char *identity, char *optional)
 	break;
       default:
 	break;
-    }
+      }
   }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function jump", 3);
   my_log(__func__, optional, 3);
-  my_put_nbr(p->x);
-  my_put_nbr(p->y);
-  my_putstr("\n");
   return (generate_output(success));
 }
 
 char		*self_stats(t_game_manager **manager, char *identity, char *optional)
 {
-  char		log[50];
   char		str[15];
-  char		*test;
   t_player	*p;
 
-  p = (*manager)->get_player(identity);
-  if ((*manager)->ready) {
-    sprintf(log, "manager ready, parameter: %s", identity);
-    sprintf(str, "%d", p->energy);
-    test = generate_output_param(SUCCESS, str);
-    return (test);
-  }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function self_stat", 3);
-  my_log(__func__, optional, 3);
+  if ((p = (*manager)->get_player(identity)) == NULL)
+    return (NULL);
+  if ((*manager)->ready)
+    {
+      sprintf(str, "%d", p->energy);
+      return (generate_output_param(SUCCESS, str));
+    }
+  my_log(__func__, optional, 4);
   return (generate_output(FAIL));
 }
 
@@ -755,13 +679,11 @@ char		*inspect(t_game_manager **manager, char *identity, char *optional)
 	return (NULL);
   if ((*manager)->ready && p->action > 5 && !p->disabled)
     {
-      sprintf(log, "manager ready, parameter: %s", identity);
       if ((p = (*manager)->get_player(identity)) == NULL)
 	return (NULL);
       if ((adv = (*manager)->get_player(optional)) == NULL)
 	{
-	  sprintf(log, "%s?", adv->identity);
-	  my_log(__func__, log, 2);
+	  sprintf(log, "%s?", optional);
 	  return (generate_output_param(FAIL, log));
 	}
       else
@@ -770,30 +692,22 @@ char		*inspect(t_game_manager **manager, char *identity, char *optional)
 	  return (generate_output_param(SUCCESS, log));
 	}
     }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function inspect", 3);
-  my_log(__func__, optional, 3);
   return (generate_output(FAIL));
 }
 
 char		*next(t_game_manager **manager, char *identity, char *optional)
 {
-  char		log[50];
   t_player	*p;
 
-  if ((*manager)->ready) {
-    sprintf(log, "manager ready, parameter: %s", identity);
-    my_log(__func__, log, 4);
-    sprintf(log, "%s decided to pass", identity);
-    p = (*manager)->get_player(identity);
-    p->action = 0;
-  }
-  else
-    sprintf(log, "manager not ready, parameter: %s", identity);
-  my_log(__func__, "call function next", 3);
-  my_log(__func__, optional, 3);
-  return (identity);
+  if ((*manager)->ready)
+    {
+      if ((p = (*manager)->get_player(identity)) == NULL)
+	return (NULL);
+      p->action = 0;
+      return (generate_output(SUCCESS));
+    }
+  my_log(__func__, optional, 4);
+  return (generate_output(FAIL));
 }
 
 /*

--- a/server/src/server/exec.c
+++ b/server/src/server/exec.c
@@ -22,7 +22,17 @@ char	**parse_input(char *input)
 {
   char	**arr;
 
-  if ((arr = my_split(input, '|')) == NULL)
+  if (input == NULL)
+    {
+      my_log(__func__, "input == NULL", 4);
+      if ((arr = malloc(sizeof(*arr) * 2)) == NULL)
+	return (NULL);
+      if ((arr[0] = my_strdup("selfid|")) == NULL)
+	return (NULL);
+      if ((arr[1] = my_strdup("no argument provide")) == NULL)
+	return (NULL);
+    }
+  else if ((arr = my_split(input, '|')) == NULL)
     return (NULL);
   if (arr[1] == NULL
       && (arr[1] = my_strdup("no argument provide")) == NULL)
@@ -47,25 +57,25 @@ char		*exec(	char *input,
   char		**inputs;
   char		*output;
 
-  my_log(__func__, "start", 3);
   commands = get_commands();
   if ((inputs = parse_input(input)) == NULL)
     return (NULL);
   if ((hash = hash_command(inputs[0])) == HCOMMANDERR)
-    my_log(__func__, "retrieve hash error", 4);
+    my_log(__func__, "retrieve hash error", 2);
   if (hash != HCOMMANDUNKNOW)
     {
-      sprintf(log, "execution of function %s", inputs[0]);
+      sprintf(log, "EXEC %s", inputs[0]);
       my_log(__func__, log, 3);
       if ((output = commands[hash](manager, active_id, inputs[1])) == NULL)
 	{
 	  sprintf(log, "execution of function %s failed", inputs[0]);
-	  my_log(__func__, log, 2);
+	  my_log(__func__, log, 1);
 	  if ((output = my_strdup("ko|server error")) == NULL)
 	    return (NULL);
 	  return (output);
 	}
-      my_log(__func__, output, 4);
+      sprintf(log, "RETURN %s", output);
+      my_log(__func__, log, 3);
       return (output);
     }  
   sprintf(log, "command %s doesn't exist", inputs[0]);

--- a/server/src/server/runtime.c
+++ b/server/src/server/runtime.c
@@ -61,11 +61,19 @@ int		serve_game(t_swctx **ctx, t_game_manager **manager)
   t_player	*player;
   t_player	*adversary;
   t_chain	*players;
-  
-  identify(manager, "foo", NULL);
-  identify(manager, "foo", NULL);
-  identify(manager, "foo", NULL);
-  identify(manager, "foo", NULL);
+  char		*id;
+
+  if ((id = my_strdup("0x01")) == NULL)
+    return (1);
+  identify(manager, "foo", id);
+  id = "0x02\0",
+  identify(manager, "foo", id);
+  id = "0x03\0",
+  identify(manager, "foo", id);
+  id = "0x04\0",
+  identify(manager, "foo", id);
+  id = "0x05\0",
+  identify(manager, "foo", id);
   gi = (*manager)->get_info();
   players = (*manager)->get_players();
 

--- a/server/src/server/runtime.c
+++ b/server/src/server/runtime.c
@@ -23,6 +23,7 @@
 #include "runtime.h"
 #include "thread.h"
 #include "thread_data.h"
+#include "softwar_test.h"
 
 int		init_network(t_swctx **ctx)
 {
@@ -50,328 +51,45 @@ int		serve_game(t_swctx **ctx, t_game_manager **manager)
   char		*ret;
   zframe_t	*address;
   char		*input;
-  //pthread_t 	tic;
-  //t_thread	*t;
+  pthread_t 	tic;
+  t_thread	*t;
   
   t_game_info	**gi;
   zmsg_t	*response;
 
-  t_command	**commands;
-  t_energy_cell	*ec;
-  t_player	*player;
-  t_player	*adversary;
-  t_chain	*players;
-  char		*id;
-
-  if ((id = my_strdup("0x01")) == NULL)
-    return (1);
-  identify(manager, "foo", id);
-  id = "0x02\0",
-  identify(manager, "foo", id);
-  id = "0x03\0",
-  identify(manager, "foo", id);
-  id = "0x04\0",
-  identify(manager, "foo", id);
-  id = "0x05\0",
-  identify(manager, "foo", id);
   gi = (*manager)->get_info();
-  players = (*manager)->get_players();
-
-  (*manager)->set_players_pos(players, 4);
-  
-  /*
-  ** pour init le hashage des commandes
-  */
-  commands = get_commands();
-  
-  if (commands == NULL)
-    my_log(__func__, "im a shitty action to imply commands and compile", 4);
-  /*
-  ** on crée un player, on le place en x2y0
-  ** on le fait regarder en bas  
-  */
-  if ((player = (*manager)->get_player("0x01")) == NULL)
+  t = init_thread(*ctx, *gi);
+  if (pthread_create(&tic, NULL, tic_thread, t) == -1)
     {
-      my_log(__func__, "fail retrieving player by id 0x01", 4);
-      return (1);
+      my_log(__func__, "thread init error", 1);
+      perror("pthread_create");
+      return EXIT_FAILURE;
     }
-  player->looking = 3;
-  player->x = 2;
-  player->y = 0;
-  player->action = 5000; 
-  /*
-  ** on ajoute une energy cell de value 2017 juste en face de lui
-  ** position 1 dans le tableau de watch
-  */
-  if ((ec = create_energy_cell(2, 1, 2017)) == NULL)
-    {
-      my_log(__func__, "fail creating energy cell", 4);
-      return (1);
-    }
-  if (add_link(&((*gi)->energy_cells), ec))
-    {
-      my_log(__func__, "failed adding energy cell in front of player", 4);
-      return (1);
-    }
-   /*
-  ** on déplace un joueur en diagonale droite de lui
-  ** position 4 dans le tableau attendu après watch
-  */
-  if ((adversary = (*manager)->get_player("0x02")) == NULL)
-    {
-      my_log(__func__, "failed retrieving adversary with id 0x02!", 4);
-      return (1);
-    }
-  adversary->x = 1;
-  adversary->y = 2;
-  /*
-  ** watch: on veut ["energy", "empty", "empty", "0x02"]
-  */
-  sprintf(log, "player original position: x = %d, y: %d", player->x, player->y);
-  my_log(__func__, log, 4);
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("watch", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-
-  /*
-  ** on veut ok|
-  */
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("forward", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-
-  /*
-  ** on veut 50 sur le premier log
-  */
-  sprintf(log, "Energy possessed by player before gather: %d", player->energy);
-  my_log(__func__, log, 4);
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("gather", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  /*
-  ** on veut 50 + 2017 = 2067
-  */
-  sprintf(log, "Energy possessed by player after gather: %d", player->energy);
-  my_log(__func__, log, 4);
-  /*
-  ** les déplacements, on va lui faire contourner 0x02 en passant par x3
-  ** soit leftfwd, rightfwd, right, forward et watch...
-  */
-
-  
-  player->action = 5000;
-  sprintf(log, "ORIGINAL position of player: x: %d, y: %d", player->x, player->y);
-  my_log(__func__, log, 3);
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("leftfwd", manager, "0x01")) == NULL)
-    return (1);
-  sprintf(log, "new position of player: x: %d, y: %d vue: %d", player->x, player->y, player->looking);
-  my_log(__func__, log, 3);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-my_log(__func__, "before call to exec", 4);
- sprintf(log, "position: x: %d, y: %d looking: %d before rightfwd", player->x, player->y, player->looking);
-  my_log(__func__, log, 4);
- 
-  if ((ret = exec("rightfwd", manager, "0x01")) == NULL)
-    return (1);
-  sprintf(log, "new position of player: x: %d, y: %d looking: %d after rightfw", player->x, player->y, player->looking);
-  my_log(__func__, log, 3);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  my_log(__func__, log, 3);
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("right", manager, "0x01")) == NULL)
-    return (1);
-  sprintf(log, "new position of player: x: %d, y: %d", player->x, player->y);
-  my_log(__func__, log, 3);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("forward", manager, "0x01")) == NULL)
-    return (1);
-  sprintf(log, "new position of player: x: %d, y: %d", player->x, player->y);
-  my_log(__func__, log, 3);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  /*
-  ** On veut ["0x02", "empty", "empty", empty"]
-  */
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("watch", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "new position of player: x: %d, y: %d", player->x, player->y);
-  my_log(__func__, log, 3);
-
-  /*
-  ** le spy shit
-  */
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("inspect|0x02", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "inspector energy: %d, action: %d, disabled: %d, adversary energy: %d, action: %d, disabled: %d", player->energy, player->action, player->disabled, adversary->energy, adversary->action, adversary->disabled);
-  my_log(__func__, log, 3);
-
-  /*
-  ** le bourre pif
-  */
-  my_log(__func__, "before call to exec", 4);
-  if ((ret = exec("attack", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed", 4);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "attacker energy: %d, action: %d, disabled: %d, adversary energy: %d, action: %d, disabled: %d", player->energy, player->action, player->disabled, adversary->energy, adversary->action, adversary->disabled);
-  my_log(__func__, log, 3);
-
-  /*
-  ** On veut x:0, y=2
-  */
-  my_log(__func__, "before call to exec for jump", 3);
-  sprintf(log, "energy == %d", player->energy);
-  my_log(__func__, log, 3);
-  if ((ret = exec("jump", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed for jump", 3);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "new position of player: x: %d, y: %d after jump", player->x, player->y);
-  my_log(__func__, log, 3);
-  sprintf(log, "energy == %d", player->energy);
-  my_log(__func__, log, 3);
-  /*
-  ** on veut une erreur pour jump in wall donc un ko
-  */
-  my_log(__func__, "before call to exec for jump in wall", 3);
-  if ((ret = exec("jump", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed for jump in wall", 3);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "new position of player: x: %d, y: %d after jump", player->x, player->y);
-  my_log(__func__, log, 3);
-
-  /*
-  ** on crée une erreur sur le saut sur un player
-  */
-  player->looking = 1;
-  sprintf(log, "looking  %d", player->looking);
-  my_log(__func__, log, 3);
-  my_log(__func__, "before call to exec for jump on player adversary", 3);
-  if ((ret = exec("jump", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed for jump on adversary", 3);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "new position of player: x: %d, y: %d after jump on player", player->x, player->y);
-  my_log(__func__, log, 4);
-
-  /*
-  ** on lui dit d'attendre le prochain tour on veut que ses points tombent à 0
-  */
-  sprintf(log, "action  %d", player->action);
-  my_log(__func__, log, 3);
-  my_log(__func__, "before call to exec for next", 3);
-  if ((ret = exec("next", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed for next", 3);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "player waiting next turn, action: %d", player->action);
-  my_log(__func__, log, 3);
-
-/*
-  **on veut qu'il quite et qu'il ne fasse plus partie des joueurs
-  */
-  sprintf(log, "action  %d", player->action);
-  my_log(__func__, log, 3);
-  my_log(__func__, "before call to exec for leave", 3);
-  if ((ret = exec("leave", manager, "0x02")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed for leave", 3);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "player left");
-  my_log(__func__, log, 3);
-
-  /*
-  **on veut que 01 selfstat
-  */
-
-  (*manager)->ready = 1;
-  my_put_nbr(player->energy);
-  my_putstr("\n\n\n");
-  my_log(__func__, "before call to exec for selfstat", 3);
-  if ((ret = exec("selfstats", manager, "0x01")) == NULL)
-    return (1);
-  my_log(__func__, "call to exec passed for selfstat", 3);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  sprintf(log, "player left");
-  my_log(__func__, log, 3);
-
-  
-  /*
-  ** On passe aux actions sur adversaire dans le prochain...
-  */
-  
-  if ((response = init_poll(ctx)) == NULL)
-    return (1);
-  address = zmsg_pop(response);
-  if (((*ctx)->active_id = my_strdup(zmsg_popstr(response))) == NULL)
-    return (1);
-  input = zmsg_popstr(response);
-  sprintf(log, "active id: %s, input: %s", (*ctx)->active_id, input);
-  my_log(__func__, log, 3);
-  if ((ret = exec(input, manager, (*ctx)->active_id)) == NULL)
-    return (1);
-  sprintf(log, "return: %s", ret);
-  my_log(__func__, log, 3);
-  zmsg_pushstr(response, ret);
-  zmsg_pushstr(response, (*ctx)->active_id);
-  zmsg_push(response, address);
-  zmsg_send(&response, (*ctx)->active_socket->socket);
-  my_log(__func__, "zmsg sent", 3);
-    
-   /*t = init_thread(*ctx, *gi);
-  if (pthread_create(&tic, NULL, tic_thread, t) == -1) {
-    my_putstr("erroooooor");
-    perror("pthread_create");
-    return EXIT_FAILURE;
-  }*/
   while (!zsys_interrupted)
     {
-    if ((response = init_poll(ctx)) == NULL)
-    return (1);
+      if ((response = init_poll(ctx)) == NULL)
+	return (1);
       address = zmsg_pop(response);
       if (((*ctx)->active_id = my_strdup(zmsg_popstr(response))) == NULL)
 	return (1);
       input = zmsg_popstr(response);
-      sprintf(log, "active id: %s, input: %s", (*ctx)->active_id, input);
-      my_log(__func__, log, 3);
-      if ((ret = exec(input, manager, (*ctx)->active_id)) == NULL)
-	return (1);
-      sprintf(log, "return: %s", ret);
-      my_log(__func__, log, 3);
+      if (input != NULL
+	  && my_strlen(input) > 0)
+	{
+	  sprintf(log, "active id: %s, input: %s", (*ctx)->active_id, input);
+	  my_log(__func__, log, 3);
+	  if ((ret = exec(input, manager, (*ctx)->active_id)) == NULL)
+	    return (1);
+	  sprintf(log, "return: %s", ret);
+	  my_log(__func__, log, 3);
+	  zmsg_pushstr(response, ret);
+	}
+      else
+	{
+	  sprintf(log, "%s", "ko|empty");
+	  if ((ret = my_strdup(log)) == NULL)
+	    return (1);
+	}
       zmsg_pushstr(response, ret);
       zmsg_pushstr(response, (*ctx)->active_id);
       zmsg_push(response, address);
@@ -385,18 +103,24 @@ int			init_runtime()
 {
   t_swctx		*ctx;
   t_game_manager	*manager;
-
+  
   ctx = get_swctx();
   manager = get_game_manager();
   manager->set_map_size(ctx->size);
-  if(init_network(&ctx) == 1) {
-    my_putstr("init sockets faileds");
-    return (0);
-  }
-  if (serve_game(&ctx, &manager))
+  if (ctx->test == 1)
+    test_softwar(&manager);
+  else
     {
-      my_log(__func__, "serving game failed", 1);
-      return (1);
+      if(init_network(&ctx) == 1)
+	{
+	  my_putstr("init sockets faileds");
+	  return (0);
+	}
+      if (serve_game(&ctx, &manager))
+	{
+	  my_log(__func__, "serving game failed", 1);
+	  return (1);
+	}
     }
   free_hashes();
   manager->free(); // free game_info static structure

--- a/server/src/server/thread.c
+++ b/server/src/server/thread.c
@@ -74,55 +74,56 @@ void 		*tic_thread(void *manager)
 {
   t_thread	*thread = (t_thread *)(manager);
   zsock_t	*pub;
-  t_swsock	*pub_sw;
   json_object	*json;
   uint		cycle;
   int		dead_count;
   int		count;
   int		nb_player;
-  char		output[50];
-  char		*malloc_output;
+  char		output[1024];
 
   srand(time(NULL));
   count = 0;
   cycle = thread->ctx->cycle;
   pub = ((t_swsock *)(thread->ctx->sockets->first->content))->socket;
-  pub_sw = (t_swsock *)(thread->ctx->sockets->first->content);
-  my_log(__func__, "socket check: ", 4);
-  my_log(__func__, pub_sw->name, 4);
   if (thread == NULL)
-    my_log(__func__, "thread is null", 4);
+    {
+      my_log(__func__, "thread is null", 1);
+      pthread_exit(NULL);
+    }
   if (thread->info == NULL)
-    my_log(__func__, "thread info is null", 4);
-  while (!zsys_interrupted) {
-    usleep(cycle);
-    undisabledme(&(thread->info));
-    if (thread->info->game_status == 1) {
-      zstr_sendf(pub, "%s %d", "Softwar", GAME_START);
+    {
+      my_log(__func__, "thread info is null", 1);
+      pthread_exit(NULL);
+   }
+  while (!zsys_interrupted)
+    {
+      usleep(cycle);
+      undisabledme(&(thread->info));
+      if (thread->info->game_status == 1)
+	zstr_sendf(pub, "%s %d", "Softwar", GAME_START);
+      dead_count = dead(thread->info->players);
+      nb_player = (4 - dead_count);
+      while (dead_count > count)
+	{
+	  zstr_sendf(pub, "%s %d", "Softwar", CLIENT_DEAD);
+	  count++;
+	  my_log(__func__, "client dead\n", 3);
+	}
+      if (nb_player < 2)
+	{
+	  zstr_sendf(pub, "%s %d", "Softwar", CLIENT_WIN);
+	  zstr_sendf(pub, "%s %d", "Softwar", GAME_END);
+	  thread->info->game_status = 0;
+	  my_log(__func__, "client win, game is end\n", 3);
+	}
+      json = game_info_to_json(thread->info);
+      sprintf(output, "%s %d %s", "Softwar", CYCLE, json_object_to_json_string(json));
+      my_log(__func__, output, 5);
+      zstr_send(pub, output);
+      if (energy_fall(&thread->info))
+	pthread_exit(NULL);
+      refresh_ap(&thread->info);
+      count = 0;
     }
-    dead_count = dead(thread->info->players);
-    nb_player = (4 - dead_count);
-    while (dead_count > count) {
-      zstr_sendf(pub, "%s %d", "Softwar", CLIENT_DEAD);
-      count++;
-      my_log(__func__, "client dead\n", 3);
-    }
-    if (nb_player < 2)
-      {
-	 zstr_sendf(pub, "%s %d", "Softwar", CLIENT_WIN);
-	 zstr_sendf(pub, "%s %d", "Softwar", GAME_END);
-	 thread->info->game_status = 0;
-	 my_log(__func__, "client win, game is end\n", 3);
-      }
-    json = game_info_to_json(thread->info);
-    sprintf(output, "%s %d %s l.101", "Softwar", CYCLE, json_object_to_json_string(json));
-    if ((malloc_output = my_strdup(output)) == NULL)
-      return (NULL);
-    my_log(__func__, malloc_output, 3);
-    zstr_send(pub, malloc_output);
-    energy_fall(&thread->info);
-    refresh_ap(&thread->info);
-    count = 0;
-  }
   pthread_exit(NULL);
 }

--- a/server/src/test/softwar_test.c
+++ b/server/src/test/softwar_test.c
@@ -1,0 +1,242 @@
+/*
+** softwar_test.c for SoftWar in 
+** 
+** Made by CASTELLARNAU Aurelien
+** Login   <castel_a@etna-alternance.net>
+** 
+** Started on  Wed Sep 27 13:25:49 2017 CASTELLARNAU Aurelien
+** Last update Wed Sep 27 16:05:05 2017 CASTELLARNAU Aurelien
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "libmy.h"
+#include "softwar_ctx.h"
+#include "game_manager.h"
+#include "exec.h"
+#include "softwar_test.h"
+
+void	init_players(t_game_manager **manager)
+{
+  char	*id;
+  
+  if ((id = my_strdup("0x01")) == NULL)
+    return;
+  identify(manager, "foo", id);
+  id = "0x02\0";
+  identify(manager, "foo", id);
+  id = "0x03\0";
+  identify(manager, "foo", id);
+  id = "0x04\0";
+  identify(manager, "foo", id);
+  id = "0x05\0";
+  identify(manager, "foo", id);
+  (*manager)->set_players_pos((*manager)->get_players(), 4);
+}
+
+t_player	**make_test_context(t_game_manager **manager)
+{
+  t_game_info	**gi;
+  t_command	**commands;
+  t_player	**p_adv;
+  t_player	*player;
+  t_player	*adversary;
+  t_energy_cell	*ec;
+  
+  /*                   
+  ** pour init le hashage des commandes                     
+  */
+  commands = get_commands();
+  if (commands == NULL)
+    my_log(__func__, "im a shitty action to imply commands and compile", 4);
+  if ((gi = (*manager)->get_info()) == NULL)
+    return (NULL);
+  /*                   
+  ** on get un player, on le place en x2y0
+  ** on le fait regarder en bas                     
+  */
+  if ((player = (*manager)->get_player("0x01")) == NULL)
+    {
+      my_log(__func__, "fail retrieving player by id 0x01", 4);
+      return (NULL);
+    }
+  player->looking = 3;
+  player->x = 2;
+  player->y = 0;
+  player->action = 5000;
+  /*                   
+  ** on ajoute une energy cell de value 2017 juste en face de lui
+  ** position 1 dans le tableau de watch                     
+  */
+  if ((ec = create_energy_cell(2, 1, 2017)) == NULL)
+    {
+      my_log(__func__, "fail creating energy cell", 4);
+      return (NULL);
+    }
+  if (add_link(&((*gi)->energy_cells), ec))
+    {
+      my_log(__func__, "failed adding energy cell in front of player", 4);
+      return (NULL);
+    }
+  /*                  
+  ** on déplace un joueur en diagonale droite de lui
+  ** position 4 dans le tableau attendu après watch
+  */
+  if ((adversary = (*manager)->get_player("0x02")) == NULL)
+    {
+      my_log(__func__, "failed retrieving adversary with id 0x02!", 4);
+      return (NULL);
+    }
+  adversary->x = 1;
+  adversary->y = 2;
+  if ((p_adv = malloc(sizeof(t_player*) * 2)) == NULL)
+    return (NULL);
+  int i;
+  for (i = 0; i < 2; i++)
+    if ((p_adv[i] = malloc(sizeof(t_player))) == NULL)
+      return (NULL);
+  p_adv[0] = player;
+  p_adv[1] = adversary;
+  return (p_adv);
+}
+
+int	assert_str(char *expected, char *must_be)
+{
+  int	valid;
+  char	log[100];
+  
+  valid = my_strcmp(expected, must_be);
+  if (!valid)
+    sprintf(log, "TEST OK: %s == %s", expected, must_be);
+  else
+    sprintf(log, "TEST FAILED: %s != %s", expected, must_be);
+  return (valid);
+}
+
+int	assert_command(t_game_manager **manager, char *command, char *target, char *must_be)
+{
+  char	*to_test;
+  char	log[100];
+
+  if ((to_test = exec(command, manager, target)) == NULL)
+    return (1);
+   if (my_strcmp(to_test, must_be) != 0)
+     sprintf(log, "TEST on %s FAILED \nexpected: %s \noutput: %s", command, must_be, to_test);
+  else
+    sprintf(log, "TEST on %s SUCCEED", command);
+   my_log(__func__, log, 3);
+  return (0);
+}
+
+int		test_softwar(t_game_manager **manager)
+{
+  char		*id;
+  t_player	**p_adv;
+  t_player	*player;
+  t_player	*adversary;
+  char		expected[100];
+
+  my_log(__func__, "SOFTWAR TESTING PROCESS", 3);
+  init_players(manager);
+  if ((p_adv = make_test_context(manager)) == NULL)
+    return (1);
+  player = p_adv[0];
+  adversary = p_adv[1];
+  id = player->identity;
+
+  // WATCH
+  assert_command(manager, "watch", id, "ok|[\"energy\", \"empty\", \"empty\", \"0x02\"]");
+  // FORWARD
+  assert_command(manager, "forward", id, "ok|");
+  // CHECK ENERGY
+  sprintf(expected, "%d", player->energy);
+  assert_str(expected, "50");
+  // GATHER
+  assert_command(manager, "gather", id, "ok|");
+  // CHECK ENERGY
+  sprintf(expected, "%d", (player->energy + 2017));
+  assert_str(expected, "2067");
+  // CHECK POSITION AND LOOKING
+  sprintf(expected, "%d", player->x);
+  assert_str(expected, "2");
+  sprintf(expected, "%d", player->y);
+  assert_str(expected, "1");
+  sprintf(expected, "%d", player->looking);
+  assert_str(expected, "3");
+  // LEFTFWD
+  assert_command(manager, "leftfwd", id, "ok|");
+  // CHECK POSITION AND LOOKING
+  sprintf(expected, "%d", player->x);
+  assert_str(expected, "3");
+  sprintf(expected, "%d", player->y);
+  assert_str(expected, "1");
+  sprintf(expected, "%d", player->looking);
+  assert_str(expected, "2");
+  // RIGHTFWD
+  assert_command(manager, "rightfwd", id, "ok|");
+  // CHECK POSITION AND LOOKING
+  sprintf(expected, "%d", player->x);
+  assert_str(expected, "3");
+  sprintf(expected, "%d", player->y);
+  assert_str(expected, "2");
+  sprintf(expected, "%d", player->looking);
+  assert_str(expected, "3");
+  // RIGHT
+  assert_command(manager, "right", id, "ok|");
+  // CHECK POSITION AND LOOKING
+  sprintf(expected, "%d", player->x);
+  assert_str(expected, "3");
+  sprintf(expected, "%d", player->y);
+  assert_str(expected, "2");
+  sprintf(expected, "%d", player->looking);
+  assert_str(expected, "0");
+  // FORWARD
+  assert_command(manager, "forward", id, "ok|");
+  // CHECK POSITION AND LOOKING
+  sprintf(expected, "%d", player->x);
+  assert_str(expected, "2");
+  sprintf(expected, "%d", player->y);
+  assert_str(expected, "2");
+  sprintf(expected, "%d", player->looking);
+  assert_str(expected, "0");
+  // WATCH
+  assert_command(manager, "watch", id, "ok|[\"0x02\", \"empty\", \"empty\", \"empty\"]");
+  // INSPECT|0x02
+  assert_command(manager, "inspect|0x02", id, "ok|50");
+  // ATTACK
+  assert_command(manager, "attack", id, "ok|");
+  // JUMP
+  assert_command(manager, "jump", id, "ok|"); 
+  // CHECK POSITION AND LOOKING
+  sprintf(expected, "%d", player->x);
+  assert_str(expected, "0");
+  sprintf(expected, "%d", player->y);
+  assert_str(expected, "2");
+  sprintf(expected, "%d", player->looking);
+  assert_str(expected, "0");
+  // CHECK ENERGY
+  sprintf(expected, "%d", (player->energy - 2));
+  assert_str(expected, "2065");
+  // ERROR ON JUMP
+  player->looking = 1;
+  adversary->x = 0;
+  adversary->y = 0;
+  assert_command(manager, "jump", id, "ko|"); 
+  // CHECK POSITION AND LOOKING
+  sprintf(expected, "%d", player->x);
+  assert_str(expected, "0");
+  sprintf(expected, "%d", player->y);
+  assert_str(expected, "2");
+  sprintf(expected, "%d", player->looking);
+  assert_str(expected, "1");
+  // NEXT
+  assert_command(manager, "next", id, "ok|");
+  // CHECK ACTIONS PTS
+  sprintf(expected, "%d", player->action);
+  assert_str(expected, "0");
+  // LEAVE
+  assert_command(manager, "leave", id, "ok|");
+  // SELFSTAT
+  assert_command(manager, "selfstat", id, "ok|2065");
+  return (0);
+}

--- a/server/src/tools/argument.c
+++ b/server/src/tools/argument.c
@@ -24,11 +24,13 @@ void		help()
   my_putstr_color("cyan", "Default -v value is info\n");
   my_putstr_color("cyan", "Without verbose mode, log error in error.log\n");
   my_putstr_color("cyan", "./demo [-log] ![filepath], set a filepath for logs\n");
+  my_putstr_color("cyan", "./demo [-ticfile] [filepath], send Game Info logging in [filepath]\n");
   my_putstr_color("cyan", "./demo [-proto] !int[int...4], display the differents notifications\n");
   my_putstr_color("cyan", "./demo [-rep-port] !int > 0 port for REP/REQ\n");
   my_putstr_color("cyan", "./demo [-pub-port] !int > 0 port for PUB/SUB\n");
   my_putstr_color("cyan", "./demo [-cycle] !int > 0 time in micro sec between two ticks\n");
   my_putstr_color("cyan", "./demo [-map-size] 0 < !int < 8 size for a side of the map\n");
+  my_putstr_color("cyan", "./demo [-test] launch tests, not the program\n");
 }
 
 /*
@@ -47,6 +49,8 @@ t_chain		*get_options()
   t_option	*pub_port;
   t_option	*cycle;
   t_option	*map;
+  t_option	*test;
+  t_option	*tic_file;
   
   if ((options = create_chain(free_options_in_chain)) == NULL)
     {
@@ -71,7 +75,12 @@ t_chain		*get_options()
     }
   if ((log_file = new_option(OPTIONNAL, 1, 0, "-log", build_logger)) == NULL)
     {
-      devlog(__func__, "create option protocol failed", 1); 
+      devlog(__func__, "create option log_file failed", 1); 
+      return (NULL);
+    }
+  if ((tic_file = new_option(OPTIONNAL, 1, 0, "-ticfile", build_logger)) == NULL)
+    {
+      devlog(__func__, "create option ticfile failed", 1); 
       return (NULL);
     }
   if ((rep_port = new_option(OPTIONNAL, 1, 0, "-rep-port", init_swctx)) == NULL)
@@ -94,6 +103,11 @@ t_chain		*get_options()
       devlog(__func__, "create option map size failed", 1); 
       return (NULL);
     }
+  if ((test = new_option(OPTIONNAL, 0, 0, "-test", init_swctx)) == NULL)
+    {
+      devlog(__func__, "create option test failed", 1); 
+      return (NULL);
+    }
   if (add_link(&options, protocol))
     {
       devlog(__func__, "add protocol option to chain failed", 1);
@@ -107,6 +121,11 @@ t_chain		*get_options()
   if (add_link(&options, log_file))
     {
       devlog(__func__, "add log_file option to chain failed", 1);
+      return (NULL);
+    }
+  if (add_link(&options, tic_file))
+    {
+      devlog(__func__, "add tic_file option to chain failed", 1);
       return (NULL);
     }
   if (add_link(&options, rep_port))
@@ -129,6 +148,11 @@ t_chain		*get_options()
       devlog(__func__, "add map option to chain failed", 1);
       return (NULL);
     }
+  if (add_link(&options, test))
+    {
+      devlog(__func__, "add test option to chain failed", 1);
+      return (NULL);
+    }
   return (options);
 }
 
@@ -149,7 +173,9 @@ int	execute(t_option *option)
     (*(void (*)(void))option->action)();
   if (!my_strcmp(opt, "-v") || !my_strcmp(opt, "-log")
       || !my_strcmp(opt, "-rep-port") || !my_strcmp(opt, "-pub-port")
-      || !my_strcmp(opt, "-cycle"))
+      || !my_strcmp(opt, "-cycle")
+      || !my_strcmp(opt, "-test")
+      || !my_strcmp(opt, "-ticfile"))
     (*(void (*)(char*, t_chain*))option->action)(opt, option->parameters);
   if (!my_strcmp(opt, "-proto"))
     (*(void (*)(t_chain*))option->action)(option->parameters);


### PR DESCRIPTION
Jolis logs,
Les tests se lancent avec l'option -test. Ne lance pas le programme.
L'option -ticfile [pathfile] permet désormais de renseigner un fichier de log séparé pour le thread, comme -log pour les logs.
Gestion d'erreur: ajout de multiples if sur des fonctions retournant des erreurs.
 (libmy/logger, les appels à get_player(), energy_fall)
Le free de la active_socket du ctx déclenchait un invalid_free => fix
Attention particulière à porter sur l'enregistrement des joueurs avec le vrai client... sur des cas limites (déco/reco) le comportement est foireu...